### PR TITLE
fix register_activation_hook, register_deactivation_hook

### DIFF
--- a/dx-plugin-base.php
+++ b/dx-plugin-base.php
@@ -265,7 +265,7 @@ class DX_Plugin_Base {
 	 *
 	 */
 	function dx_on_activate() {
-		register_activation_hook( __FILE__, 'dx_on_activate_callback' );
+		register_activation_hook( __FILE__, array(&$this, 'dx_on_activate_callback') );
 	}
 	
 	function dx_on_activate_callback() {
@@ -277,7 +277,7 @@ class DX_Plugin_Base {
 	 * 
 	 */
 	function dx_on_deactivate() {
-		register_activation_hook( __FILE__, 'dx_on_deactivate_callback' );
+		register_deactivation_hook( __FILE__, array(&$this, 'dx_on_deactivate_callback') );
 	}
 	
 	function dx_on_deactivate_callback() {


### PR DESCRIPTION
Fixed PHP warning:

```
call_user_func_array() expects parameter 1 to be a valid callback, function 'dx_on_activate_callback' not found or invalid function name
```

This kind of patch is effective for [you plugin on Wordpress.org](http://wordpress.org/extend/plugins/dx-plugin-base/) .
